### PR TITLE
Revert "add felix-services.jar to system server jars"

### DIFF
--- a/device-felix.mk
+++ b/device-felix.mk
@@ -381,5 +381,3 @@ PRODUCT_VENDOR_PROPERTIES += \
 PRODUCT_PRODUCT_PROPERTIES += \
     ro.quick_start.oem_id=00e0 \
     ro.quick_start.device_id=felix
-
-PRODUCT_SYSTEM_SERVER_JARS += system_ext:felix-services


### PR DESCRIPTION
This is handled in adevtool now, including automatic skipping of this change for prep builds.