### PR TITLE
add ALLOW_MISSING_DEPENDENCIES := true

### DIFF
--- a/device-felix.mk
+++ b/device-felix.mk
@@ -24,6 +24,8 @@ TARGET_LINUX_KERNEL_VERSION := $(RELEASE_KERNEL_FELIX_VERSION)
 TARGET_KERNEL_DIR ?= $(RELEASE_KERNEL_FELIX_DIR)
 TARGET_BOARD_KERNEL_HEADERS ?= $(RELEASE_KERNEL_FELIX_DIR)/kernel-headers
 
+ALLOW_MISSING_DEPENDENCIES := true
+
 $(call inherit-product-if-exists, vendor/google_devices/felix/prebuilts/device-vendor-felix.mk)
 $(call inherit-product-if-exists, vendor/google_devices/gs201/prebuilts/device-vendor.mk)
 $(call inherit-product-if-exists, vendor/google_devices/gs201/proprietary/device-vendor.mk)


### PR DESCRIPTION
This is currently needed for inclusion of felix-services system_server JAR.

comet has an equivalent comet-services JAR, but ALLOW_MISSING_DEPENDENCIES is already set for it in device/google/zumapro.

It's not clear whether stock Pixel OS uses ALLOW_MISSING_DEPENDENCIES for felix too or if it uses some other configuration.