### PR TITLE
update IDisplay to V15

### DIFF
--- a/device_framework_matrix_product_felix.xml
+++ b/device_framework_matrix_product_felix.xml
@@ -1,7 +1,7 @@
 <compatibility-matrix version="1.0" type="framework" level="7">
     <hal format="aidl" optional="true">
       <name>com.google.hardware.pixel.display</name>
-        <version>13</version>
+        <version>15</version>
         <interface>
             <name>IDisplay</name>
             <instance>secondary</instance>


### PR DESCRIPTION
default display already handled in gs201 repository (https://github.com/GrapheneOS/device_google_gs201/commit/dfdcbfbcbe16892591689e82ef7803c2eb10f3fa)

```
diff -ru --color felix-BP1A.250505.005.B1/product/etc/vintf/compatibility_matrix.xml felix-BP2A.250605.031.A2/product/etc/vintf/compatibility_matrix.xml
--- felix-BP1A.250505.005.B1/product/etc/vintf/compatibility_matrix.xml	2008-12-31 16:00:00.000000000 -0800
+++ felix-BP2A.250605.031.A2/product/etc/vintf/compatibility_matrix.xml	2008-12-31 16:00:00.000000000 -0800
-    <hal format="aidl" optional="true">
+    <hal format="aidl">
         <name>com.google.hardware.pixel.display</name>
-        <version>13</version>
+        <version>15</version>
         <interface>
             <name>IDisplay</name>
             <instance>default</instance>
         </interface>
     </hal>
-    <hal format="aidl" optional="true">
+    <hal format="aidl">
         <name>com.google.hardware.pixel.display</name>
-        <version>13</version>
+        <version>15</version>
         <interface>
             <name>IDisplay</name>
             <instance>secondary</instance>
         </interface>
     </hal>
```